### PR TITLE
Replace TIMING_INFO with runtime verbose flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ target_include_directories(vortrace_core PUBLIC
   ${CMAKE_SOURCE_DIR}/include
 )
 target_compile_features(vortrace_core PUBLIC cxx_std_17)
-target_compile_definitions(vortrace_core PRIVATE TIMING_INFO)
 # tell your core library about pybind11's include dirs:
 target_link_libraries(vortrace_core
   PUBLIC

--- a/src/brute_projection.cpp
+++ b/src/brute_projection.cpp
@@ -5,9 +5,7 @@
 #include <cstring>
 #include <algorithm>
 #include <limits>
-#ifdef TIMING_INFO
 #include <chrono>
-#endif
 
 void BruteProjection::makeProjection(const PointCloud &cloud, ReductionMode mode)
 {
@@ -54,9 +52,7 @@ void BruteProjection::makeProjection(const PointCloud &cloud, ReductionMode mode
   }
 
   if (vortrace::verbose) std::cout << "Making projection...\n";
-#ifdef TIMING_INFO
   auto start = std::chrono::high_resolution_clock::now();
-#endif
   #pragma omp parallel for schedule(dynamic,256) collapse(2)
   for(size_t i = 0; i < npix_x; i++)
     for(size_t j = 0; j < npix_y; j++)
@@ -92,12 +88,11 @@ void BruteProjection::makeProjection(const PointCloud &cloud, ReductionMode mode
       proj_data[i] *= deltaz;
   }
 
-#ifdef TIMING_INFO
+  if (vortrace::verbose) {
     auto stop = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
-    if (vortrace::verbose) std::cout << "Projection generation took " << duration.count() << " milliseconds.\n";
-#endif
-  if (vortrace::verbose) std::cout << "Projection complete." << std::endl;
+    std::cout << "Projection generation took " << duration.count() << " milliseconds." << std::endl;
+  }
 }
 
 void BruteProjection::saveProjection(const std::string savename) const

--- a/src/pointcloud.cpp
+++ b/src/pointcloud.cpp
@@ -1,7 +1,5 @@
 #include "pointcloud.hpp"
-#ifdef TIMING_INFO
 #include <chrono>
-#endif
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <iostream>
@@ -108,19 +106,15 @@ void PointCloud::buildTree()
   //Now build tree
   //reset here (vs make_unique) in case snap is reloaded
   if (vortrace::verbose) std::cout << "Building tree...\n";
-#ifdef TIMING_INFO
   auto start = std::chrono::high_resolution_clock::now();
-#endif
   tree.reset(new my_kd_tree_t(3,*this,nanoflann::KDTreeSingleIndexAdaptorParams(10 /* max leaf */)));
   tree->buildIndex();
   tree_built = true;
-#ifdef TIMING_INFO
+  if (vortrace::verbose) {
     auto stop = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
-    if (vortrace::verbose) std::cout << "Tree build took " << duration.count() << " milliseconds." << std::endl;
-#else
-    if (vortrace::verbose) std::cout << " Done." << std::endl;
-#endif
+    std::cout << "Tree build took " << duration.count() << " milliseconds." << std::endl;
+  }
 }
 
 size_t PointCloud::queryTree(const Point &query_pt) const

--- a/src/projection.cpp
+++ b/src/projection.cpp
@@ -3,9 +3,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstring>
-#ifdef TIMING_INFO
 #include <chrono>
-#endif
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
@@ -63,9 +61,7 @@ void Projection::makeProjection(const PointCloud &cloud, ReductionMode mode)
   std::fill(proj_data.begin(), proj_data.end(), 0.0);
 
   if (vortrace::verbose) std::cout << "Making projection...\n";
-#ifdef TIMING_INFO
   auto start = std::chrono::high_resolution_clock::now();
-#endif
   std::exception_ptr eptr = nullptr;
   #pragma omp parallel for schedule(dynamic,256)
   for(size_t i = 0; i < ngrid; i++)
@@ -91,13 +87,11 @@ void Projection::makeProjection(const PointCloud &cloud, ReductionMode mode)
   }
   if (eptr) std::rethrow_exception(eptr);
 
-#ifdef TIMING_INFO
+  if (vortrace::verbose) {
     auto stop = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
-    if (vortrace::verbose) std::cout << "Projection generation took " << duration.count() << " milliseconds." << std::endl;
-#else
-    if (vortrace::verbose) std::cout << "Projection complete." << std::endl;
-#endif
+    std::cout << "Projection generation took " << duration.count() << " milliseconds." << std::endl;
+  }
 }
 
 py::array_t<double> Projection::returnProjection(void) const

--- a/src/slice.cpp
+++ b/src/slice.cpp
@@ -2,9 +2,7 @@
 #include "slice.hpp"
 #include <iostream>
 #include <fstream>
-#ifdef TIMING_INFO
 #include <chrono>
-#endif
 
 void Slice::makeSlice(const PointCloud &cloud)
 {
@@ -37,9 +35,7 @@ void Slice::makeSlice(const PointCloud &cloud)
   slice_data.resize(ngrid * nfields);
 
   if (vortrace::verbose) std::cout << "Making slice...\n";
-#ifdef TIMING_INFO
   auto start = std::chrono::high_resolution_clock::now();
-#endif
 
   #pragma omp parallel for schedule(dynamic,256) collapse(2)
   for(size_t i = 0; i < npix_x; i++)
@@ -55,12 +51,12 @@ void Slice::makeSlice(const PointCloud &cloud)
       for(size_t f = 0; f < nfields; f++)
         slice_data[base + f] = cloud.get_field(result_idx, f);
     }
-#ifdef TIMING_INFO
+
+  if (vortrace::verbose) {
     auto stop = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
-    if (vortrace::verbose) std::cout << "Slice generation took " << duration.count() << " microseconds\n";
-#endif
-  if (vortrace::verbose) std::cout << "Slice complete." << std::endl;
+    std::cout << "Slice generation took " << duration.count() << " microseconds." << std::endl;
+  }
 }
 
 void Slice::saveSlice(const std::string savename) const


### PR DESCRIPTION
## Summary
- Remove the `TIMING_INFO` compile-time preprocessor macro from all source files and `CMakeLists.txt`
- Timing code now always compiles and executes behind the existing `vortrace::verbose` runtime flag
- No recompilation needed to toggle timing output — just call `set_verbose(True)` from Python

## Test plan
- [x] All 40 existing tests pass
- [x] Build succeeds without `TIMING_INFO` compile definition
- [x] No remaining references to `TIMING_INFO` in codebase

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)