### PR TITLE
Fix split-point-outside-segment-bounds with float32 positions

### DIFF
--- a/src/ray.cpp
+++ b/src/ray.cpp
@@ -85,17 +85,17 @@ Float Ray::findSplitPointDistance(const PointCloud &cloud,
     }
   }
 
+  // Analytic bisector-ray intersection
   Float s = findSplitPointDistance(pos1, pos2);
 
-  // If the analytic result is valid, return it directly
-  if (s < std::numeric_limits<Float>::max() * 0.5)
+  // If the analytic result is valid and within the segment, return it.
+  if (s < std::numeric_limits<Float>::max() * 0.5 &&
+      s >= s_lo - TOLERANCE && s <= s_hi + TOLERANCE)
     return s;
 
-  // Parallel bisector: binary search along [s_lo, s_hi] to find
-  // where the cell identity changes or to locate an intermediate cell.
-  std::cerr << "Warning: parallel bisector detected between cells "
-            << id1 << " and " << id2 << std::endl;
-
+  // Fall back to binary search when the analytic result is outside the
+  // segment (can happen with reduced-precision positions, e.g. float32)
+  // or when the bisector is parallel to the ray.
   Float lo = s_lo;
   Float hi = s_hi;
 
@@ -122,7 +122,8 @@ Float Ray::findSplitPointDistance(const PointCloud &cloud,
     }
   }
 
-  throw std::runtime_error("Binary search did not converge for parallel bisector");
+  throw std::runtime_error("Binary search did not converge for split point "
+    "between cells " + std::to_string(id1) + " and " + std::to_string(id2));
 }
 
 size_t Ray::perpPerturbToFindCell(const Point &pos, const PointCloud &cloud,

--- a/tests/test_degenerate.py
+++ b/tests/test_degenerate.py
@@ -90,3 +90,27 @@ class TestDegenerateSplitPoints:
         result = integrate_ray(pos, fields, vol, bb,
                                [2.0, 2.0, -0.1], [2.0, 2.0, 4.1])
         assert result > 0.0, f"Expected positive integral, got {result}"
+
+    def test_float32_precision_positions(self):
+        """Positions centered in float32 then converted to float64.
+
+        Regression test for split-point-outside-segment-bounds error
+        when positions have float32 quantization noise (e.g. from the
+        arepo snapshot loader).
+        """
+        n = 10
+        pos, fields, vol, bb = make_cubic_lattice(n)
+
+        # Shift to a large offset, round-trip through float32, shift back.
+        # This mimics loading coordinates as float32 and recentering.
+        offset = np.array([500.0, 500.0, 500.1])
+        pos_f32 = (pos + offset).astype(np.float32)
+        pos_f32 -= offset.astype(np.float32)
+        pos_degraded = pos_f32.astype(np.float64)
+
+        # Diagonal ray through the lattice
+        start = [-0.1, -0.1, -0.1]
+        end = [n - 0.9, n - 0.9, n - 0.9]
+        result = integrate_ray(pos_degraded, fields, vol, bb, start, end)
+        expected = ray_length(start, end)
+        np.testing.assert_allclose(result, expected, rtol=1e-3)


### PR DESCRIPTION
## Summary

- When positions have float32-level precision (e.g. loaded via the `arepo` library which processes coordinates as float32), the analytic bisector-ray intersection in `findSplitPointDistance` can land slightly outside the expected segment bounds, causing a `RuntimeError`
- Instead of throwing, the four-argument `findSplitPointDistance` now falls back to binary search (already implemented for parallel bisectors) when the analytic result is out of bounds. The binary search uses k-NN queries to find where the cell identity actually changes, so it is always consistent with the rest of the ray-tracing algorithm
- Added regression test for float32-precision positions in `test_degenerate.py`

## Test plan

- [x] `tmp/reproduce_bug.py` completes without error (previously threw `RuntimeError`)
- [x] `pytest tests/test_degenerate.py -v` — all 7 tests pass including new `test_float32_precision_positions`
- [x] `pytest tests/ -v` — full test suite passes (IO tests fail due to unrelated sandbox temp file restrictions)

Thanks to Scott Lucchini for helping find this bug\!

🤖 Generated with [Claude Code](https://claude.com/claude-code)